### PR TITLE
Added Hosted Tokenization support

### DIFF
--- a/examples/hosted-tokenization.php
+++ b/examples/hosted-tokenization.php
@@ -1,0 +1,94 @@
+<?php
+require '../lib/Moneris.php';
+
+$errors = array();
+
+if (! empty($_POST)) {
+	// use the testing server for the demo:
+	$moneris = Moneris::create(
+		array(
+			'api_key' => 'xxxxxxxxxxxxxxxxxxx', // Under Admin / Store Settings
+			'store_id' => 'monca00yyy',
+			'environment' => Moneris::ENV_STAGING
+		)
+	);
+
+	try {
+
+		// try to make the purchase:
+		$result = $moneris->purchase($_POST);
+
+		if ($result->was_successful()) {
+
+			// hooray!
+			exit("Hot diggity dog!");
+
+		} else {
+
+			exit();
+
+		}
+
+	} catch (Moneris_Exception $e) {
+		$errors[] = $e->getMessage();
+	}
+}
+?>
+<html>
+<head>
+	<title> Outer Frame - Merchant Page</title>
+
+	<script>
+
+		function doMonerisSubmit()
+		{
+			var monFrameRef = document.getElementById('monerisFrame').contentWindow;
+			monFrameRef.postMessage('','https://esqa.moneris.com/HPPtoken/index.php');
+			return false;
+		}
+
+		var respMsg = function(e)
+		{
+			var respData = eval("(" + e.data + ")");
+			document.getElementById("monerisResponse").innerHTML = e.origin + " SENT " + " - " + respData.responseCode + "-" + respData.dataKey + "-" + respData.errorMessage;
+
+			if (respData.dataKey) {
+				document.getElementById('data_key').value = respData.dataKey;
+				document.getElementById('form').submit();
+			}
+
+		}
+
+		window.onload = function()
+		{
+			if (window.addEventListener)
+			{
+				window.addEventListener ("message", respMsg, false);
+			}
+			else
+			{
+				if (window.attachEvent)
+				{
+					window.attachEvent("onmessage", respMsg);
+				}
+			}
+		}
+	</script>
+</head>
+<body>
+
+<div id=monerisResponse></div>
+
+<!-- Get token under Admin / Hosted Tokenization (domain must match URL where iFrame will be located) -->
+<iframe id=monerisFrame src="https://esqa.moneris.com/HPPtoken/index.php?id=htZZZZZZZZZZZ&css_body=background:white;&css_textbox=border-width:2px;&css_textbox_pan=width:140px;&display_labels=1&enable_exp=1&css_textbox_exp=width:40px;&enable_cvd=1&css_textbox_cvd=width:40px" frameborder='0' width="200" height="120"></iframe>
+
+<form method="post" id="form">
+	<p><input name="amount" type="text" placeholder="Amount" required></p>
+	<p><input name="order_id" type="text" placeholder="Order ID" required></p>
+	<p><input name="data_key" id="data_key" type="text" placeholder="Data key" readonly></p>
+</form>
+
+<input type=button onClick=doMonerisSubmit() value="submit iframe">
+
+</body>
+</html>

--- a/examples/hosted-tokenization.php
+++ b/examples/hosted-tokenization.php
@@ -7,8 +7,8 @@ if (! empty($_POST)) {
 	// use the testing server for the demo:
 	$moneris = Moneris::create(
 		array(
-			'api_key' => 'xxxxxxxxxxxxxxxxxxx', // Under Admin / Store Settings
-			'store_id' => 'monca00yyy',
+			'api_key' => 'yesguy', // Under Admin / Store Settings
+			'store_id' => 'store1',
 			'environment' => Moneris::ENV_STAGING
 		)
 	);

--- a/lib/Moneris/Gateway.php
+++ b/lib/Moneris/Gateway.php
@@ -193,6 +193,9 @@ class Moneris_Gateway
 	 *			- amount float
 	 * 			- expdate int 4 digit date YYMM
 	 * 			OR
+	 *			- data_key string A token/data key, used with Hosted Tokenization
+	 *			- amount float
+	 * 			OR
 	 *			- expiry_month int 2 digit representation of the expiry month (01-12)
 	 * 			- expiry_year int last two digits of the expiry year
 	 * 		Required (if AVS is enabled):
@@ -217,7 +220,7 @@ class Moneris_Gateway
 	 */
 	public function preauth(array $params)
 	{
-		$params['type'] = 'preauth';
+		$params['type'] = (isset($params['data_key'])) ? 'res_preauth_cc' : 'preauth';
 		$params['crypt_type'] = 7;
 		$transaction = $this->transaction($params);
 	 	return $this->_process($transaction);
@@ -232,6 +235,9 @@ class Moneris_Gateway
 	 * 			- cc_number int Any non-numeric characters will be stripped
 	 *			- amount float
 	 * 			- expdate int 4 digit date YYMM
+	 * 			OR
+	 *			- data_key string A token/data key, used with Hosted Tokenization
+	 *			- amount float
 	 * 			OR
 	 *			- expiry_month int 2 digit representation of the expiry month (01-12)
 	 * 			- expiry_year int last two digits of the expiry year
@@ -257,7 +263,7 @@ class Moneris_Gateway
 	 */
 	public function purchase(array $params)
 	{
-		$params['type'] = 'purchase';
+		$params['type'] = (isset($params['data_key'])) ? 'res_purchase_cc' : 'purchase';
 		$params['crypt_type'] = 7;
 		$transaction = $this->transaction($params);
 	 	return $this->_process($transaction);

--- a/lib/Moneris/Transaction.php
+++ b/lib/Moneris/Transaction.php
@@ -143,6 +143,19 @@ class Moneris_Transaction
 					if (! isset($params['PaRes'])) $errors[] = 'PaRes not provided';
 					if (! isset($params['MD'])) $errors[] = 'Merchant details "MD" not provided';
 					break;
+
+				case 'res_preauth_cc':
+					if (! isset($params['data_key']) || '' == $params['data_key']) $errors[] = 'Data Key not provided';
+					if (! isset($params['order_id']) || '' == $params['order_id']) $errors[] = 'Order ID not provided';
+					if (! isset($params['amount']) || '' == $params['amount']) $errors[] = 'Amount not provided';
+					break;
+
+				case 'res_purchase_cc':
+					if (! isset($params['data_key']) || '' == $params['data_key']) $errors[] = 'Data Key not provided';
+					if (! isset($params['order_id']) || '' == $params['order_id']) $errors[] = 'Order ID not provided';
+					if (! isset($params['amount']) || '' == $params['amount']) $errors[] = 'Amount not provided';
+					break;
+
 				default:
 					$errors[] = $params['type'] . ' is not a support transaction type';
 			}

--- a/lib/Moneris/Transaction.php
+++ b/lib/Moneris/Transaction.php
@@ -101,7 +101,7 @@ class Moneris_Transaction
 					break;
 
 				case 'completion':
-					if (! isset($params['comp_amount']) || '' === $params['comp_amount']) $errors[] = 'Amount not provided';
+					if (! isset($params['comp_amount']) || '' == $params['comp_amount']) $errors[] = 'Amount not provided';
 					if (! isset($params['order_id']) || '' == $params['order_id']) $errors[] = 'Order ID not provided';
 					if (! isset($params['txn_number']) || '' == $params['txn_number']) $errors[] = 'Transaction number not provided';
 					break;
@@ -144,16 +144,24 @@ class Moneris_Transaction
 					if (! isset($params['MD'])) $errors[] = 'Merchant details "MD" not provided';
 					break;
 
-				case 'res_preauth_cc':
-					if (! isset($params['data_key']) || '' == $params['data_key']) $errors[] = 'Data Key not provided';
-					if (! isset($params['order_id']) || '' == $params['order_id']) $errors[] = 'Order ID not provided';
-					if (! isset($params['amount']) || '' == $params['amount']) $errors[] = 'Amount not provided';
+				case 'res_purchase_cc':
+					if (! isset($params['data_key']) || '' == $params['data_key']) $errors[] = 'Data key not provided';
+					if (! isset($params['order_id'])) $errors[] = 'Order ID not provided';
+					if (! isset($params['amount'])) $errors[] = 'Amount not provided';
 					break;
 
-				case 'res_purchase_cc':
-					if (! isset($params['data_key']) || '' == $params['data_key']) $errors[] = 'Data Key not provided';
-					if (! isset($params['order_id']) || '' == $params['order_id']) $errors[] = 'Order ID not provided';
-					if (! isset($params['amount']) || '' == $params['amount']) $errors[] = 'Amount not provided';
+				case 'res_preauth_cc':
+					if (! isset($params['data_key']) || '' == $params['data_key']) $errors[] = 'Data key not provided';
+					if (! isset($params['order_id'])) $errors[] = 'Order ID not provided';
+					if (! isset($params['amount'])) $errors[] = 'Amount not provided';
+					break;
+
+				case 'res_update_cc':
+					if (! isset($params['data_key']) || '' == $params['data_key']) $errors[] = 'Data key not provided';
+					break;
+
+				case 'res_delete':
+					if (! isset($params['data_key']) || '' == $params['data_key']) $errors[] = 'Data key not provided';
 					break;
 
 				default:


### PR DESCRIPTION
This is a small patch that adds support for [Moneris Hosted Tokenization](https://developer.moneris.com/Documentation/NA/E-Commerce%20Solutions/Hosted%20Solutions/Hosted%20Tokenization).

It re-uses pretty much all existing methods and accepts a new argument "data_key" for each of them. Data key is a unique transaction token generated by Moneris' iFrame. Hosted tokenization is used by organizations that can't or won't store personal customers information on their servers.

No test were written since it's pretty much impossible to generate a data key dynamically. I did add an example based on Moneris' documentation.

Let me know what you think. Thanks!