### PR TITLE
Prevent library fail on ResponseCode == '000'

### DIFF
--- a/lib/Moneris/Result.php
+++ b/lib/Moneris/Result.php
@@ -294,7 +294,7 @@ class Moneris_Result
 
 		// was it a successful transaction?
 		// any response code greater than 49 is an error code:
-		if ((int) $receipt->ResponseCode >= 50 || (int) $receipt->ResponseCode == 0) {
+		if ((int) $receipt->ResponseCode >= 50) {
 
 			// trying to make some sense of this... grouping them as best as I can:
 			switch ($receipt->ResponseCode) {


### PR DESCRIPTION
@ironkeith I have one small update for your great library again. 

The ResponseCode of '000' is indicates an approved transaction: https://developer.moneris.com/More/Testing/Financial%20Response%20Codes We had few transactions which were invalidated in our system while being authorized at Moneris. They had `ResponseCode = '000'`

I've removed 0 from the codes which are treated as invalid and that helped.

Could you please merge it in, and create new version (release/tag) probably? 